### PR TITLE
Use config file instead of argparse

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,3 +32,10 @@ train:
   early_stopping_patience: 10
   early_stopping_min_delta: 0.001
   model_save_path: "src/models/checkpoints/lstm_model.pth"
+
+# Default configuration for scripts
+model_type: "lstm"
+skip_cv: false
+checkpoint: "src/models/checkpoints/lstm_model.pth"
+test_folder: "data/test"
+

--- a/inference_seq.py
+++ b/inference_seq.py
@@ -1,4 +1,3 @@
-import argparse
 import os
 import glob
 import json
@@ -42,7 +41,7 @@ def load_model(model_type: str, config: dict, checkpoint: str):
     return model
 
 
-def main(args):
+def main():
     # load config
     with open("config.yaml") as f:
         config = yaml.safe_load(f)
@@ -55,10 +54,10 @@ def main(args):
     min_seq_len = stats["min_seq_len"]
     max_seq_len = config["data"].get("max_sequence_length", min_seq_len)
 
-    checkpoint = args.checkpoint or config["train"]["model_save_path"]
-    model = load_model(args.model_type, config, checkpoint)
-
-    test_folder = args.test_folder
+    model_type = config.get("model_type", "lstm")
+    checkpoint = config.get("checkpoint", config["train"]["model_save_path"])
+    test_folder = config.get("test_folder", "data/test")
+    model = load_model(model_type, config, checkpoint)
     test_files = glob.glob(os.path.join(test_folder, "*/*.xls"))
 
     for fpath in test_files:
@@ -86,8 +85,4 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Sequence model inference")
-    parser.add_argument("--model_type", choices=["lstm", "conv"], default="lstm", help="Model architecture used during training")
-    parser.add_argument("--checkpoint", type=str, default=None, help="Path to model weights")
-    parser.add_argument("--test_folder", type=str, default="data/test", help="Folder with test samples")
-    main(parser.parse_args())
+    main()

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import argparse
 import yaml
 
 from utils.data_loader import ExcelDatasetTimeSeries
@@ -6,13 +5,11 @@ from utils.help_training import cross_validate, train_full
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Full training pipeline")
-    parser.add_argument("--model_type", choices=["lstm", "conv"], default="lstm")
-    parser.add_argument("--skip_cv", action="store_true", help="Skip cross-validation step")
-    args = parser.parse_args()
-
     with open("config.yaml") as f:
         config = yaml.safe_load(f)
+
+    model_type = config.get("model_type", "lstm")
+    skip_cv = config.get("skip_cv", False)
 
     full_ds = ExcelDatasetTimeSeries(
         root_folder=config["data"]["root_folder"],
@@ -25,10 +22,10 @@ def main():
     indices = list(range(len(full_ds)))
     labels = [full_ds.labels[i] for i in indices]
 
-    if not args.skip_cv:
-        cross_validate(args.model_type, config, indices, labels)
+    if not skip_cv:
+        cross_validate(model_type, config, indices, labels)
 
-    train_full(args.model_type, config)
+    train_full(model_type, config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove `argparse` in main training script and sequence inference script
- add default parameters to `config.yaml`

## Testing
- `python -m py_compile main.py`
- `python -m py_compile inference_seq.py`


------
https://chatgpt.com/codex/tasks/task_e_6874065567a0832a9d857f9076848bad