### PR TITLE
Improve sequential inference output

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -39,6 +39,11 @@ model.eval()
 test_folder = "data/test"
 test_files = glob.glob(os.path.join(test_folder, "*/*.xls"))
 
+# Map predicted indices to folder names for display
+class_names = sorted(
+    [d for d in os.listdir(test_folder) if os.path.isdir(os.path.join(test_folder, d))]
+)
+
 # === Predict on each file ===
 for fpath in test_files:
     try:
@@ -66,7 +71,10 @@ for fpath in test_files:
             pred = torch.argmax(probs).item()
             confidence = probs[pred].item()
 
-        print(f"File: {os.path.basename(fpath)} | Prediction: {pred} | Confidence: {confidence:.2%}")
+        label = class_names[pred] if pred < len(class_names) else str(pred)
+        print(
+            f"File: {os.path.basename(fpath)} | Prediction: {label} | Confidence: {confidence:.2%}"
+        )
 
     except Exception as e:
         print(f"Failed to process {os.path.basename(fpath)}: {e}")

--- a/inference_seq.py
+++ b/inference_seq.py
@@ -60,6 +60,11 @@ def main():
     model = load_model(model_type, config, checkpoint)
     test_files = glob.glob(os.path.join(test_folder, "*/*.xls"))
 
+    # Map predicted indices to folder names for clearer output
+    class_names = sorted(
+        [d for d in os.listdir(test_folder) if os.path.isdir(os.path.join(test_folder, d))]
+    )
+
     for fpath in test_files:
         try:
             df = load_excel(fpath, config["data"]["columns"], time_format="%I:%M:%S%p")
@@ -79,7 +84,10 @@ def main():
                 pred = torch.argmax(probs).item()
                 conf = probs[pred].item()
 
-            print(f"File: {os.path.basename(fpath)} | Prediction: {pred} | Confidence: {conf:.2%}")
+            label = class_names[pred] if pred < len(class_names) else str(pred)
+            print(
+                f"File: {os.path.basename(fpath)} | Prediction: {label} | Confidence: {conf:.2%}"
+            )
         except Exception as e:
             print(f"Failed to process {os.path.basename(fpath)}: {e}")
 


### PR DESCRIPTION
## Summary
- label predictions using class folder names in `inference_seq.py`

## Testing
- `python -m py_compile inference_seq.py`
- `python inference_seq.py` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_687416de7d1c832ab9bce3afddf0337a