### PR TITLE
Save threshold and adjust training

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,6 +32,7 @@ train:
   early_stopping_patience: 10
   early_stopping_min_delta: 0.001
   model_save_path: "src/models/checkpoints/lstm_model.pth"
+  threshold_path: "src/models/checkpoints/threshold.json"
 
 # Default configuration for scripts
 model_type: "lstm"


### PR DESCRIPTION
## Summary
- store optimal threshold path in config
- use validation accuracy for early stopping in final model training and save the threshold
- apply saved threshold during inference

## Testing
- `python -m py_compile utils/help_training.py inference_seq.py`

------
https://chatgpt.com/codex/tasks/task_e_687431c38d6c832a955c0a9690966f0a